### PR TITLE
Fix memory leak

### DIFF
--- a/nss_tacplus.c
+++ b/nss_tacplus.c
@@ -608,7 +608,6 @@ lookup_tacacs_user(struct pwbuf *pb)
             static const char *delim = ", \t\n";
             bool islocal = 0;
             user = strtok(list, delim);
-            list = NULL;
             while (user) {
                 if(!strcmp(user, pb->name)) {
                     islocal = 1;


### PR DESCRIPTION
Was setting list variable to NULL before calling free, causing buffer on the heap to never be freed. Most likely was passing list to a single call to strtok() (list was first non-NULL then NULL), then restructured code and neglected to nuke the list = NULL statement.